### PR TITLE
Add test harness and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test --test-concurrency=1 'test/**/*.test.js'"
   },
   "keywords": [
     "user-story",

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+test('test harness is wired up', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary

Bootstraps the built-in `node --test` runner so the subsequent security PRs from issue #3 can ship behaviour tests alongside their changes.

- `test/smoke.test.js` — sanity check that the runner is wired up
- `npm test` script — `node --test --test-concurrency=1 'test/**/*.test.js'` (concurrency=1 so future integration tests don't collide on ports)
- `.github/workflows/test.yml` — runs `npm test` on push to `main` and on PRs, Node 24 to match the Dockerfile

No production code changes.

## Context

First in a series of small PRs from issue #3 (security review). Per your suggestion to tackle findings individually, opening the test infrastructure first so each subsequent fix can ship with a regression test. Happy to drop or shape this differently if you'd prefer.

## Test plan

- [x] `npm test` passes locally
- [ ] CI workflow runs on this PR