### PR TITLE
Configure allowed origins via STORYMAPS_ALLOWED_ORIGINS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Comma-separated list of origins allowed to write to the API and open
+# WebSocket connections. Overrides the built-in storymaps.io defaults.
+# Localhost / 127.0.0.1 are always allowed for local development.
+# STORYMAPS_ALLOWED_ORIGINS=https://maps.example.com,https://www.example.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test --test-concurrency=1 'test/**/*.test.js'"
   },
   "keywords": [
     "user-story",

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -2,13 +2,24 @@
 // See note in server.js for rationale on sharing client transfer code.
 import { importFromYaml } from '../src/transfer/yaml.js';
 
-// Allowed origins for API writes and WebSocket connections
-// localhost is always allowed for development
-const ALLOWED_ORIGINS = new Set([
+export const parseOrigins = (s) =>
+  new Set((s || '').split(',').map(x => x.trim()).filter(Boolean));
+
+// Allowed origins for API writes and WebSocket connections.
+// STORYMAPS_ALLOWED_ORIGINS (comma-separated) overrides these defaults.
+// localhost / 127.0.0.1 are always allowed for development (see isOriginAllowed).
+const DEFAULT_ORIGINS = [
   'https://storymaps.io',
   'https://www.storymaps.io',
   'https://new.storymaps.io',
-]);
+];
+
+export const buildAllowedOrigins = (envValue) => {
+  const env = parseOrigins(envValue);
+  return env.size > 0 ? env : new Set(DEFAULT_ORIGINS);
+};
+
+const ALLOWED_ORIGINS = buildAllowedOrigins(process.env.STORYMAPS_ALLOWED_ORIGINS);
 
 export const isOriginAllowed = (origin) => {
   if (!origin) return false;

--- a/test/origin-parse.test.js
+++ b/test/origin-parse.test.js
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { parseOrigins, buildAllowedOrigins } from '../server/middleware.js';
+
+describe('parseOrigins', () => {
+  test('empty input yields empty Set', () => {
+    assert.deepEqual([...parseOrigins('')], []);
+  });
+
+  test('comma-separated values become a Set', () => {
+    const out = parseOrigins('https://a.example,https://b.example');
+    assert.ok(out.has('https://a.example'));
+    assert.ok(out.has('https://b.example'));
+    assert.equal(out.size, 2);
+  });
+
+  test('whitespace around entries is trimmed', () => {
+    const out = parseOrigins('  https://a.example ,   https://b.example  ');
+    assert.ok(out.has('https://a.example'));
+    assert.ok(out.has('https://b.example'));
+    assert.equal(out.size, 2);
+  });
+
+  test('empty entries between commas are filtered', () => {
+    const out = parseOrigins('https://a.example,,https://b.example,');
+    assert.equal(out.size, 2);
+  });
+});
+
+describe('buildAllowedOrigins', () => {
+  test('falls back to hardcoded storymaps.io defaults when env is empty', () => {
+    const out = buildAllowedOrigins('');
+    assert.ok(out.has('https://storymaps.io'));
+  });
+
+  test('env value replaces defaults entirely', () => {
+    const out = buildAllowedOrigins('https://my.example');
+    assert.ok(out.has('https://my.example'));
+    assert.ok(!out.has('https://storymaps.io'));
+    assert.equal(out.size, 1);
+  });
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+test('test harness is wired up', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary

Self-hosters can now set `STORYMAPS_ALLOWED_ORIGINS` (comma-separated) to configure the API/WebSocket origin allowlist, instead of patching `server/middleware.js`. When the env var is unset, the built-in `storymaps.io` defaults still apply, so the hosted instance behaviour is unchanged.

- `parseOrigins(s)` — pure parser, exported for tests
- `buildAllowedOrigins(env)` — falls back to defaults on empty env
- `.env.example` — new file, documents the var

Addresses finding #7 from issue #3.

## Stacked on #5

This branch contains the test harness from #5. Its diff will clean up automatically once #5 merges. Marked draft until then — please review #5 first.

## Test plan

- [x] `npm test` — 6 new tests in `test/origin-parse.test.js`, all green
- [x] hosted defaults still apply when env unset (regression test)
- [x] env value replaces defaults entirely when set