### PR TITLE
Gate X-Forwarded-For on TRUST_PROXY env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test --test-concurrency=1 'test/**/*.test.js'"
   },
   "keywords": [
     "user-story",

--- a/server/rate-limit.js
+++ b/server/rate-limit.js
@@ -5,12 +5,20 @@ const RATE_WINDOW = 60_000;
 const rateLimitMap = new Map();
 const proxyRateLimitMap = new Map();
 
-const getClientIp = (req) => {
-  const forwarded = req.headers['x-forwarded-for'];
-  // Use last entry - set by Caddy (the closest trusted proxy)
-  if (forwarded) return forwarded.split(',').pop().trim();
+// Pick the client IP. When trustProxy is true, honour the last entry
+// of X-Forwarded-For (set by the closest trusted proxy, e.g. Caddy).
+// Otherwise return the direct socket address — safe default when the
+// app is not behind a reverse proxy or the proxy is untrusted.
+export const pickClientIp = (req, { trustProxy } = {}) => {
+  if (trustProxy) {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) return forwarded.split(',').pop().trim();
+  }
   return req.socket.remoteAddress;
 };
+
+const TRUST_PROXY = process.env.TRUST_PROXY === 'true';
+const getClientIp = (req) => pickClientIp(req, { trustProxy: TRUST_PROXY });
 
 const checkLimit = (map, limit, req) => {
   const ip = getClientIp(req);
@@ -29,7 +37,9 @@ const checkLimit = (map, limit, req) => {
 export const isRateLimited = (req) => checkLimit(rateLimitMap, RATE_LIMIT, req);
 export const isProxyRateLimited = (req) => checkLimit(proxyRateLimitMap, PROXY_RATE_LIMIT, req);
 
-// Clean up stale entries every 5 minutes
+// Clean up stale entries every 5 minutes. unref() so this timer does
+// not keep the process alive on its own (matters under node --test and
+// for short-lived invocations).
 setInterval(() => {
   const cutoff = Date.now() - RATE_WINDOW;
   for (const map of [rateLimitMap, proxyRateLimitMap]) {
@@ -38,4 +48,4 @@ setInterval(() => {
       if (!timestamps.length) map.delete(ip);
     }
   }
-}, 5 * 60_000);
+}, 5 * 60_000).unref();

--- a/test/client-ip.test.js
+++ b/test/client-ip.test.js
@@ -1,0 +1,20 @@
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { pickClientIp } from '../server/rate-limit.js';
+
+describe('pickClientIp', () => {
+  test('uses socket.remoteAddress when trustProxy is false', () => {
+    const req = { socket: { remoteAddress: '10.0.0.5' }, headers: { 'x-forwarded-for': '1.2.3.4' } };
+    assert.equal(pickClientIp(req, { trustProxy: false }), '10.0.0.5');
+  });
+
+  test('uses last X-Forwarded-For entry when trustProxy is true', () => {
+    const req = { socket: { remoteAddress: '10.0.0.5' }, headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' } };
+    assert.equal(pickClientIp(req, { trustProxy: true }), '5.6.7.8');
+  });
+
+  test('falls back to socket when trustProxy is true but no XFF header', () => {
+    const req = { socket: { remoteAddress: '10.0.0.5' }, headers: {} };
+    assert.equal(pickClientIp(req, { trustProxy: true }), '10.0.0.5');
+  });
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+test('test harness is wired up', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary

`getClientIp` previously read `X-Forwarded-For` whenever it was present. That's correct behind the bundled Caddy, but spoofable when the app runs direct or behind an untrusted proxy: an attacker can send any `X-Forwarded-For` header to reset their rate-limit bucket.

- `pickClientIp(req, { trustProxy })` — pure helper, exported for tests
- `TRUST_PROXY=true` (string) is the only value that opts in; default (unset / any other value) uses `req.socket.remoteAddress`
- The 5-minute cleanup `setInterval` is now `unref()`-ed so it doesn't keep the process alive under `node --test` or other short-lived invocations

Addresses finding #6 from issue #3.

## Stacked on #5

Diff will clean up after #5 (test harness) merges. Marked draft until then.

## On `.env.example`

`TRUST_PROXY` documentation is intentionally not added to `.env.example` here — that file is introduced in #6 (origins). Happy to follow up with a docs-only PR appending the `TRUST_PROXY` section once both this and #6 land, to keep each PR's diff isolated.

## Test plan

- [x] `npm test` — 3 new tests in `test/client-ip.test.js`, all green
- [x] default (no env) returns socket.remoteAddress even when XFF present
- [x] `TRUST_PROXY=true` reads the last XFF entry
- [x] no test runner hang from the cleanup timer