### PR TITLE
Rate-limit unlock + backup POST handlers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test --test-concurrency=1 'test/**/*.test.js'"
   },
   "keywords": [
     "user-story",

--- a/server/routes/backups.js
+++ b/server/routes/backups.js
@@ -16,6 +16,11 @@ export default function register(ctx) {
   });
 
   route('POST', '/api/backups/:mapId', async (req, res, { mapId }, body) => {
+    if (ctx.isProxyRateLimited(req)) {
+      res.writeHead(429, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Too many attempts' }));
+      return;
+    }
     const data = await ctx.loadAndSerialize(mapId, req.headers.host);
     if (!data) {
       res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -41,6 +46,11 @@ export default function register(ctx) {
 
   // Register /import before /:backupId so "import" isn't captured as a backupId
   route('POST', '/api/backups/:mapId/import', async (req, res, { mapId }, body) => {
+    if (ctx.isProxyRateLimited(req)) {
+      res.writeHead(429, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Too many attempts' }));
+      return;
+    }
     const imported = Array.isArray(body?.backups) ? body.backups : [];
     if (imported.length) {
       const existing = await ctx.readJson(ctx.getBackupFile(mapId), []);

--- a/server/routes/locks.js
+++ b/server/routes/locks.js
@@ -24,6 +24,11 @@ export default function register(ctx) {
   });
 
   route('POST', '/api/lock/:mapId/unlock', async (req, res, { mapId }, body) => {
+    if (ctx.isProxyRateLimited(req)) {
+      res.writeHead(429, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Too many attempts' }));
+      return;
+    }
     const locks = await ctx.readJson(ctx.LOCK_FILE, {});
     const lock = locks[mapId];
     if (!lock?.isLocked) {
@@ -37,6 +42,11 @@ export default function register(ctx) {
   });
 
   route('POST', '/api/lock/:mapId/remove', async (req, res, { mapId }, body) => {
+    if (ctx.isProxyRateLimited(req)) {
+      res.writeHead(429, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Too many attempts' }));
+      return;
+    }
     const locks = await ctx.readJson(ctx.LOCK_FILE, {});
     const lock = locks[mapId];
     if (!lock?.isLocked) {

--- a/test/rate-limit-routes.test.js
+++ b/test/rate-limit-routes.test.js
@@ -1,0 +1,81 @@
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import registerLocks from '../server/routes/locks.js';
+import registerBackups from '../server/routes/backups.js';
+
+const captureHandlers = (register, extraCtx = {}) => {
+  const handlers = {};
+  const ctx = {
+    route: (method, path, handler) => { handlers[`${method} ${path}`] = handler; },
+    isProxyRateLimited: () => false,
+    readJson: async () => ({}),
+    writeJson: async () => {},
+    LOCK_FILE: '/dev/null',
+    getBackupFile: () => '/dev/null',
+    loadAndSerialize: async () => ({ name: 'x', steps: [] }),
+    countCards: () => 0,
+    ...extraCtx,
+  };
+  register(ctx);
+  return { handlers, ctx };
+};
+
+const fakeRes = () => {
+  const out = { status: null, body: null, headers: null };
+  return {
+    out,
+    writeHead(s, h) { out.status = s; out.headers = h; },
+    end(b) { out.body = b; },
+  };
+};
+
+const ratelimited = () => ({ isProxyRateLimited: (req) => req.__shouldLimit === true });
+
+describe('rate-limited routes return 429 when the proxy bucket is full', () => {
+  test('POST /api/lock/:mapId/unlock', async () => {
+    const { handlers } = captureHandlers(registerLocks, ratelimited());
+    const res = fakeRes();
+    await handlers['POST /api/lock/:mapId/unlock'](
+      { __shouldLimit: true, headers: {} }, res, { mapId: 'abc12345' }, {},
+    );
+    assert.equal(res.out.status, 429);
+  });
+
+  test('POST /api/lock/:mapId/remove', async () => {
+    const { handlers } = captureHandlers(registerLocks, ratelimited());
+    const res = fakeRes();
+    await handlers['POST /api/lock/:mapId/remove'](
+      { __shouldLimit: true, headers: {} }, res, { mapId: 'abc12345' }, {},
+    );
+    assert.equal(res.out.status, 429);
+  });
+
+  test('POST /api/backups/:mapId', async () => {
+    const { handlers } = captureHandlers(registerBackups, ratelimited());
+    const res = fakeRes();
+    await handlers['POST /api/backups/:mapId'](
+      { __shouldLimit: true, headers: { host: 'localhost' } }, res, { mapId: 'abc12345' }, {},
+    );
+    assert.equal(res.out.status, 429);
+  });
+
+  test('POST /api/backups/:mapId/import', async () => {
+    const { handlers } = captureHandlers(registerBackups, ratelimited());
+    const res = fakeRes();
+    await handlers['POST /api/backups/:mapId/import'](
+      { __shouldLimit: true, headers: {} }, res, { mapId: 'abc12345' }, { backups: [] },
+    );
+    assert.equal(res.out.status, 429);
+  });
+});
+
+describe('gate does not break the happy path when bucket is OK', () => {
+  test('POST /api/lock/:mapId/unlock with default ctx responds 200 when map is not locked', async () => {
+    const { handlers } = captureHandlers(registerLocks);
+    const res = fakeRes();
+    await handlers['POST /api/lock/:mapId/unlock'](
+      { headers: {} }, res, { mapId: 'abc12345' }, { passwordHash: 'x' },
+    );
+    assert.equal(res.out.status, 200);
+  });
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+test('test harness is wired up', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary

Brings the four unprotected POST handlers into line with the import/export and map routes: an over-bucket IP gets `429` with a short message. Closes:

- `POST /api/lock/:mapId/unlock` — password brute-force vector
- `POST /api/lock/:mapId/remove` — same vector, write-enabling
- `POST /api/backups/:mapId` — disk-fill via repeated 5MB-cap snapshots
- `POST /api/backups/:mapId/import` — same shape via attacker-supplied blobs

Reuses the existing `isProxyRateLimited` bucket (5/min per IP) rather than introducing a new one.

Addresses findings #3 and #4 from issue #3.

## Stacked on #5

Diff will clean up after #5 (test harness) merges. Marked draft until then.

## Test plan

- [x] `npm test` — 5 new tests in `test/rate-limit-routes.test.js`, all green
- [x] each gated route returns 429 when bucket is full
- [x] happy path still 200 when bucket is OK (regression)