### PR TITLE
Add baseline security headers to Caddyfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,19 @@
 storymaps.io {
+    header {
+        # HTTPS only, including subdomains, for one year.
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        # Stop browsers from sniffing MIME types away from the declared one.
+        X-Content-Type-Options "nosniff"
+        # Disallow framing to mitigate clickjacking.
+        X-Frame-Options "DENY"
+        # Send origin only on cross-origin navigations.
+        Referrer-Policy "strict-origin-when-cross-origin"
+        # Drop powerful APIs we do not use.
+        Permissions-Policy "geolocation=(), microphone=(), camera=()"
+        # Don't advertise the server software.
+        -Server
+    }
+
     reverse_proxy app:8080
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test --test-concurrency=1 'test/**/*.test.js'"
   },
   "keywords": [
     "user-story",

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+test('test harness is wired up', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary

Adds a `header` block to the `storymaps.io` site:

- `Strict-Transport-Security` — HTTPS-only for a year, incl. subdomains
- `X-Content-Type-Options: nosniff` — stop MIME sniffing
- `X-Frame-Options: DENY` — disallow framing (clickjacking)
- `Referrer-Policy: strict-origin-when-cross-origin` — origin only on cross-origin nav
- `Permissions-Policy` — drop unused powerful APIs (geolocation, mic, camera)
- `-Server` — don't advertise server software

**No CSP yet.** The app uses `innerHTML` in several places (`src/ui/*`, `src/features/*`) so a proper CSP needs tuning before it can be enabled without breaking rendering. Happy to follow up with a CSP audit PR if you want that next.

The `www.storymaps.io` redirect block is left untouched (301-only, no need for response headers).

Addresses finding #8 from issue #3.

## Stacked on #5

Diff will clean up after #5 (test harness) merges. Marked draft until then.

## Test plan

- [x] `caddy validate` passes (Caddy 2.x in Docker)
- [ ] verified once deployed: response headers present